### PR TITLE
Update unlink feedback

### DIFF
--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -42,9 +42,10 @@ module.exports = {
   },
 
   unlink: function(slackName, ircName) {
-    var response = "Unmapped " + slackName + "(slack) from " + ircName + "(irc)";
+    var response = "Nothing happened"
     if (ircName) {
       delete userMap[ircName];
+      response = slackName + "(slack) " + "unmapped " + ircName + "(irc)";
     } else {
       response = "";
       _.each(userMap, function(val, key, list) {


### PR DESCRIPTION
Without parameters, the feedback was saying that the initiator of the unlink was unlinked from the ircName.

But any user can unlink a slack/irc nick link, so now the feedback is saying that the initiator has unlinked the ircName (so it can work for any users)
